### PR TITLE
Add a 'cpulist' parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ Doorbells to same small core on a POWER9 small core box:
 XIVE interrupts:
 
 ```# insmod ./ipistorm.ko timeout=10 single=1 offset=8```
+
+Use `cpulist` parameter to select subsets of cpus :
+
+```# insmod ./ipistorm.ko timeout=10 single=1 offset=8 cpulist=0-7,32-39```


### PR DESCRIPTION
The format of the CPU list is the same as the other kernel parameters :

  https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html#cpu-lists

On big systems, it can be used to select subsets of cpus. For instance,
cpus of a specific chip.

Signed-off-by: Cédric Le Goater <clg@kaod.org>