### PR TITLE
Don't sleep if delay=0

### DIFF
--- a/ipistorm.c
+++ b/ipistorm.c
@@ -89,7 +89,10 @@ static int ipistorm_thread(void *data)
 		else
 			smp_call_function(do_nothing_ipi, NULL, wait);
 
-		usleep_range(delay, delay+1);
+		if (delay)
+			usleep_range(delay, delay+1);
+		else
+			cond_resched();
 	}
 
 	if (atomic_dec_and_test(&running))


### PR DESCRIPTION
I'm not sure why I haven't seen this before, but we are sleeping quite
a lot when running ipistorm.

Call cond_resched() instead of usleep_range(0, 1) if delay=0.

Signed-off-by: Anton Blanchard <anton@ozlabs.org>